### PR TITLE
Allow to specify the default translation file

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -4,7 +4,7 @@ import { AppContext } from 'ink';
 import App from '../src/components/App';
 
 /// Convert files from json to po or po to json
-const Index = ({ inputType, pattern, yes }) => {
+const Index = ({ inputType, pattern, yes, defaultLocaleFile }) => {
     return (
         <AppContext.Consumer>
             {({ exit }) => (
@@ -13,6 +13,7 @@ const Index = ({ inputType, pattern, yes }) => {
                     inputType={inputType}
                     pattern={pattern}
                     autoAccept={yes}
+                    defaultLocaleFile={defaultLocaleFile}
                 />
             )}
         </AppContext.Consumer>
@@ -26,12 +27,15 @@ Index.propTypes = {
     pattern: PropTypes.string,
     /// Boolean indicating wether to auto accept conversions
     yes: PropTypes.bool,
+    /// The name of the file to use as the default when converting json to po ("en.json" by default)
+    defaultLocaleFile: PropTypes.string,
 };
 
 Index.shortFlags = {
     inputType: 'i',
     pattern: 'p',
     yes: 'y',
+    defaultLocaleFile: 'd',
 };
 
 export default Index;

--- a/src/lib/convertJsonToPo.js
+++ b/src/lib/convertJsonToPo.js
@@ -15,17 +15,18 @@ const DefaultHeaders = {
 /**
  * Convert JSON files to PO files
  * @param {string[]} filePaths The paths of the files to convert (eg: ['home/node/myProject/i18n/en.json', 'home/node/myProject/i18n/fr.json'])
- * @param {string} defaultLocale The locale from which the po msgid entries will be extracted (default to 'en')
+ * @param {string} defaultLocaleFile The locale from which the po msgid entries will be extracted (default to 'en')
  * @param {object} defaultHeaders The PO files headers. See https://www.gnu.org/software/trans-coord/manual/gnun/html_node/PO-Header.html
  */
 export const convertFilesToPo = async (
     filePaths,
-    defaultLocale = 'en',
+    defaultLocaleFile = 'en.json',
     defaultHeaders = DefaultHeaders
 ) => {
     const locales = filePaths.map(getLocaleDescriptor);
+
     const defaultLocaleDescriptor = locales.find(
-        locale => locale.name === defaultLocale
+        locale => locale.name === defaultLocaleFile
     );
 
     const localesWithPo = await Promise.all(
@@ -44,8 +45,7 @@ export const convertFilesToPo = async (
     );
 };
 
-const extractLocaleFromFilePath = filePath =>
-    path.basename(filePath).split('.')[0];
+const extractLocaleFromFilePath = filePath => path.basename(filePath);
 
 const getLocaleDescriptor = filePath => {
     const locale = extractLocaleFromFilePath(filePath);
@@ -86,6 +86,9 @@ export const convertJSONToPo = (entries, defaultEntries) => {
 
 const convertToPoItem = entries => defaultEntry => {
     const entry = entries.find(entry => entry.key === defaultEntry.key);
+    if (!entry) {
+        throw new Error(`Missing entry for key ${defaultEntry.key}`);
+    }
     const variants = entry.value.split('||||');
     const defaultVariants = defaultEntry.value.split('||||');
 

--- a/src/lib/findFiles.js
+++ b/src/lib/findFiles.js
@@ -2,6 +2,6 @@ import globby from 'globby';
 
 export const findFiles = async patterns =>
     globby(patterns, {
-        gitignore: true,
+        gitignore: false,
         expandDirectories: false,
     });


### PR DESCRIPTION
The CLI now accept a `defaultFile` argument allowing to specify the file to use for default translations. It default to `en.json`. Those translations are used to generate the `msgid` for the PO entries